### PR TITLE
Handle cases where att has its own attribute of name="label"

### DIFF
--- a/example/import-from-cytoscape.py
+++ b/example/import-from-cytoscape.py
@@ -27,7 +27,6 @@ def _main():
         for onenode in g.nodes():
             print >>f, '\t'.join([onenode, json.dumps(g.node[onenode])])
 
-
     print 'node list is exported to {0}'.format(options.nodelist)
     
 

--- a/example/mirtarbase-example.py
+++ b/example/mirtarbase-example.py
@@ -26,7 +26,7 @@ def _main():
     with file(options.nodelist, 'w') as f:
         for onenode in g.nodes():
             print >>f, '\t'.join([onenode, json.dumps(g.node[onenode])])
-
+            print g.node[onenode]
 
     print 'node list is exported to {0}'.format(options.nodelist)
     

--- a/example/mirtarbase-example.py
+++ b/example/mirtarbase-example.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import networkx as nx
+import networkxgmml
+import json
+
+def _main():
+    parser = argparse.ArgumentParser(description="Read network from mirtarbase-sample")
+    parser.add_argument('XGMML', default=file('./mirtarbase-sample.xgmml'), help='XGMML file exported from Cytoscape  default: %(default)s', nargs='?', type=argparse.FileType('r'))
+    parser.add_argument('edgelist', default='./output/mirtarbase-sample-edgelist.txt', nargs='?', help='edge list output path  [default: %(default)s]')
+    parser.add_argument('nodelist', default='./output/mirtarbase-sample-nodelist.txt', nargs='?', help='node list output path  [default: %(default)s]')
+    options = parser.parse_args()
+
+    g = networkxgmml.XGMMLReader(options.XGMML)
+
+    print '# of edges', len(g.edges())
+    with file(options.edgelist, 'w') as f:
+        for n1, n2 in g.edges():
+            print >>f, '\t'.join([n1, n2, json.dumps(g.edge[n1][n2])])
+
+    print 'edge list is exported to {0}'.format(options.edgelist)
+
+    print '# of nodes', len(g.nodes())
+    with file(options.nodelist, 'w') as f:
+        for onenode in g.nodes():
+            print >>f, '\t'.join([onenode, json.dumps(g.node[onenode])])
+
+
+    print 'node list is exported to {0}'.format(options.nodelist)
+    
+
+if __name__ == '__main__':
+    _main()

--- a/example/mirtarbase-example.py
+++ b/example/mirtarbase-example.py
@@ -26,10 +26,12 @@ def _main():
     with file(options.nodelist, 'w') as f:
         for onenode in g.nodes():
             print >>f, '\t'.join([onenode, json.dumps(g.node[onenode])])
-            print g.node[onenode]
 
     print 'node list is exported to {0}'.format(options.nodelist)
-    
+
+    output_xgmml_file_path = './output/mirtar-output.xgmml'
+    output_xgmml = open(output_xgmml_file_path, 'w')
+    networkxgmml.XGMMLWriter(output_xgmml, g, "New Graph")
 
 if __name__ == '__main__':
     _main()

--- a/example/mirtarbase-sample.xgmml
+++ b/example/mirtarbase-sample.xgmml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graph xmlns="http://www.cs.rpi.edu/XGMML" id="1383230285965" label="miRTarBase_hsa_r4.4">
+  <att xmlns="" label="RegIN Name" name="RegIN Name" value="miRTarBase_hsa_r4.4" type="string" />
+  <att xmlns="" label="Source File" name="Source File" value="hsa_MTI.csv" type="string" />
+  <node xmlns="" id="hsa-miR-542-3p" label="hsa-miR-542-3p">
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="hsa-miR-542-3p" />
+      <att type="string" name="identifiers" value="MIMAT0003389" />
+    </att>
+    <att label="miRNA" name="miRNA" value="hsa-miR-542-3p" type="string" />
+    <att label="Species (miRNA)" name="Species (miRNA)" value="Homo sapiens" type="string" />
+    <att label="miRTarBase ID" name="miRTarBase ID" value="MIRT005363" type="string" />
+    <att label="label" name="label" value="hsa-miR-542-3p" type="string" />
+    <att label="biologicalType" name="biologicalType" value="miRNA" type="string" />
+  </node>
+  <node xmlns="" id="332" label="332">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="332" />
+      <att type="string" name="identifiers" value="O15392" />
+      <att type="string" name="identifiers" value="ENSG00000089685" />
+      <att type="string" name="identifiers" value="A3E0Z4" />
+      <att type="string" name="identifiers" value="H3BLT4" />
+      <att type="string" name="identifiers" value="A3E0Z5" />
+      <att type="string" name="identifiers" value="A3E0Z6" />
+      <att type="string" name="identifiers" value="A3E0Z7" />
+    </att>
+    <att label="label" name="label" value="BIRC5" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="332" type="string" />
+    <att label="Target Gene" name="Target Gene" value="BIRC5" type="string" />
+  </node>
+  <node xmlns="" id="3611" label="3611">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="3611" />
+      <att type="string" name="identifiers" value="B7Z1I0" />
+      <att type="string" name="identifiers" value="B7Z418" />
+      <att type="string" name="identifiers" value="E9PNR4" />
+      <att type="string" name="identifiers" value="E9PQ27" />
+      <att type="string" name="identifiers" value="Q13418" />
+      <att type="string" name="identifiers" value="E9PQ52" />
+      <att type="string" name="identifiers" value="E9PM54" />
+      <att type="string" name="identifiers" value="ENSG00000166333" />
+    </att>
+    <att label="label" name="label" value="ILK" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="3611" type="string" />
+    <att label="Target Gene" name="Target Gene" value="ILK" type="string" />
+  </node>
+  <node xmlns="" id="hsa-miR-370-3p" label="hsa-miR-370-3p">
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="hsa-miR-370-3p" />
+    </att>
+    <att label="miRNA" name="miRNA" value="hsa-miR-370-3p" type="string" />
+    <att label="Species (miRNA)" name="Species (miRNA)" value="Homo sapiens" type="string" />
+    <att label="miRTarBase ID" name="miRTarBase ID" value="MIRT001074" type="string" />
+    <att label="label" name="label" value="hsa-miR-370-3p" type="string" />
+    <att label="biologicalType" name="biologicalType" value="miRNA" type="string" />
+  </node>
+  <node xmlns="" id="1326" label="1326">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="1326" />
+      <att type="string" name="identifiers" value="P41279" />
+      <att type="string" name="identifiers" value="ENSG00000107968" />
+      <att type="string" name="identifiers" value="Q5T857" />
+      <att type="string" name="identifiers" value="Q5T853" />
+      <att type="string" name="identifiers" value="Q5T854" />
+    </att>
+    <att label="label" name="label" value="MAP3K8" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="1326" type="string" />
+    <att label="Target Gene" name="Target Gene" value="MAP3K8" type="string" />
+  </node>
+  <node xmlns="" id="1374" label="1374">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="1374" />
+      <att type="string" name="identifiers" value="Q8WZ48" />
+      <att type="string" name="identifiers" value="H3BP22" />
+      <att type="string" name="identifiers" value="P50416" />
+      <att type="string" name="identifiers" value="H3BMD2" />
+      <att type="string" name="identifiers" value="H3BUJ0" />
+      <att type="string" name="identifiers" value="H3BUV7" />
+      <att type="string" name="identifiers" value="ENSG00000110090" />
+    </att>
+    <att label="label" name="label" value="CPT1A" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="1374" type="string" />
+    <att label="Target Gene" name="Target Gene" value="CPT1A" type="string" />
+  </node>
+  <node xmlns="" id="8091" label="8091">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="8091" />
+      <att type="string" name="identifiers" value="Q1M188" />
+      <att type="string" name="identifiers" value="F5H2A4" />
+      <att type="string" name="identifiers" value="Q1M185" />
+      <att type="string" name="identifiers" value="Q1M186" />
+      <att type="string" name="identifiers" value="H0YFY4" />
+      <att type="string" name="identifiers" value="Q1M187" />
+      <att type="string" name="identifiers" value="P52926" />
+      <att type="string" name="identifiers" value="F5H6H0" />
+      <att type="string" name="identifiers" value="B2KX87" />
+      <att type="string" name="identifiers" value="F5H2U8" />
+      <att type="string" name="identifiers" value="ENSG00000149948" />
+      <att type="string" name="identifiers" value="Q8IZX8" />
+    </att>
+    <att label="label" name="label" value="HMGA2" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="8091" type="string" />
+    <att label="Target Gene" name="Target Gene" value="HMGA2" type="string" />
+  </node>
+   <node xmlns="" id="4763" label="4763">
+    <att label="Species (Target Gene)" name="Species (Target Gene)" value="Homo sapiens" type="string" />
+    <att type="list" name="identifiers">
+      <att type="string" name="identifiers" value="4763" />
+      <att type="string" name="identifiers" value="H0UIC3" />
+      <att type="string" name="identifiers" value="Q4W6X4" />
+      <att type="string" name="identifiers" value="B4DXP1" />
+      <att type="string" name="identifiers" value="Q7Z3J5" />
+      <att type="string" name="identifiers" value="B4DXH1" />
+      <att type="string" name="identifiers" value="H0Y465" />
+      <att type="string" name="identifiers" value="K7EP94" />
+      <att type="string" name="identifiers" value="P21359" />
+      <att type="string" name="identifiers" value="Q9UMU3" />
+      <att type="string" name="identifiers" value="ENSG00000196712" />
+      <att type="string" name="identifiers" value="J3KSB5" />
+    </att>
+    <att label="label" name="label" value="NF1" type="string" />
+    <att label="biologicalType" name="biologicalType" value="gene" type="string" />
+    <att label="Target Gene (Entrez ID)" name="Target Gene (Entrez ID)" value="4763" type="string" />
+    <att label="Target Gene" name="Target Gene" value="NF1" type="string" />
+  </node>
+
+  <edge xmlns="" id="3264" label="3264" source="hsa-miR-542-3p" target="332">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="20728447" type="string" />
+    <att label="Experiments" name="Experiments" value="Luciferase reporter assay//Microarray//qRT-PCR//Western blot" type="string" />
+    <att label="Support Type" name="Support Type" value="Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+  <edge xmlns="" id="3935" label="3935" source="hsa-miR-542-3p" target="3611">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="21860426" type="string" />
+    <att label="Experiments" name="Experiments" value="Immunoblot//Immunocytochemistry//Luciferase reporter assay" type="string" />
+    <att label="Support Type" name="Support Type" value="Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+  <edge xmlns="" id="3981" label="3981" source="hsa-miR-370-3p" target="4763">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="23077663" type="string" />
+    <att label="Experiments" name="Experiments" value="Luciferase reporter assay" type="string" />
+    <att label="Support Type" name="Support Type" value="Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+  <edge xmlns="" id="1205" label="1205" source="hsa-miR-370-3p" target="1326">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="17621267" type="string" />
+    <att label="Experiments" name="Experiments" value="Luciferase reporter assay//Western blot" type="string" />
+    <att label="Support Type" name="Support Type" value="Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+  <edge xmlns="" id="1954" label="1954" source="hsa-miR-370-3p" target="1374">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="20124555" type="string" />
+    <att label="Experiments" name="Experiments" value="Luciferase reporter assay//qRT-PCR//Western blot" type="string" />
+    <att label="Support Type" name="Support Type" value="Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+  <edge xmlns="" id="1964" label="1964" source="hsa-miR-370-3p" target="8091">
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="References (PMID)" name="References (PMID)" value="19179606" type="string" />
+    <att label="Experiments" name="Experiments" value="Luciferase reporter assay" type="string" />
+    <att label="Support Type" name="Support Type" value="Non-Functional MTI" type="string" />
+    <att label="interaction" name="interaction" value="MTI" type="string" />
+    <att label="datasource" name="datasource" value="miRTarBase_hsa_r4.4" type="string" />
+  </edge>
+</graph>

--- a/networkxgmml.py
+++ b/networkxgmml.py
@@ -161,7 +161,7 @@ def XGMMLWriter(file, graph, graph_name):
         - `text`:
         """
 
-        return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt')
+        return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
     def write_att_el(k, v, indent_count):
         indentation_string = ''

--- a/networkxgmml.py
+++ b/networkxgmml.py
@@ -39,6 +39,9 @@ class XGMMLParserHelper(object):
             self._current_obj = dict(attr)
 
         if tag == 'att' and (self._tagstack[-2] == 'node' or self._tagstack[-2] == 'edge') and 'value' in attr:
+            if attr['name'] == 'label':
+                attr['name'] = '@label'
+
             if attr['type'] == 'string':
                 self._current_attr[attr['name']] = attr['value']
             elif attr['type'] == 'real':

--- a/networkxgmml.py
+++ b/networkxgmml.py
@@ -39,9 +39,6 @@ class XGMMLParserHelper(object):
             self._current_obj = dict(attr)
 
         if tag == 'att' and (self._tagstack[-2] == 'node' or self._tagstack[-2] == 'edge') and 'value' in attr:
-            if attr['name'] == 'label':
-                attr['name'] = '@label'
-
             if attr['type'] == 'string':
                 self._current_attr[attr['name']] = attr['value']
             elif attr['type'] == 'real':
@@ -67,6 +64,9 @@ class XGMMLParserHelper(object):
 
         if tag == 'node':
             if 'label' in self._current_obj:
+                if 'label' in self._current_attr:
+                    self._current_attr['@label'] = self._current_attr['label']
+                    del self._current_attr['label']
                 self._graph.add_node(self._current_obj['id'], label=self._current_obj['label'], **self._current_attr)
             else:
                 self._graph.add_node(self._current_obj['id'], **self._current_attr)

--- a/networkxgmml.py
+++ b/networkxgmml.py
@@ -150,10 +150,9 @@ def XGMMLWriter(file, graph, graph_name):
 
     print >>file, """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <graph directed="1"  xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.cs.rpi.edu/XGMML">
-<att name="selected" value="1" type="boolean" />
-<att name="name" value="{0}" type="string"/>
-<att name="shared name" value="{0}" type="string"/>
-""".format(graph_name)
+  <att name="selected" value="1" type="boolean" />
+  <att name="name" value="{0}" type="string"/>
+  <att name="shared name" value="{0}" type="string"/>""".format(graph_name)
 
     def quote(text):
         """
@@ -164,6 +163,23 @@ def XGMMLWriter(file, graph, graph_name):
 
         return text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt')
 
+    def write_att_el(k, v, indent_count):
+        indentation_string = ''
+        for i in range(0, indent_count):
+            indentation_string += '  '
+        if isinstance(v, int):
+            print >>file, indentation_string + '<att name="{}" value="{}" type="integer" />'.format(k, v)
+        elif isinstance(v, bool):
+            print >>file, indentation_string + '<att name="{}" value="{}" type="boolean" />'.format(k, v)
+        elif isinstance(v, float):
+            print >>file, indentation_string + '<att name="{}" value="{}" type="real" />'.format(k, v)
+        elif hasattr(v, '__iter__'):
+            print >>file, indentation_string + '<att name="{}" type="list">'.format(k)
+            for item in v:
+                write_att_el(k, item, 3)
+            print >>file, indentation_string + '</att>'
+        else:
+            print >>file, indentation_string + '<att name="{}" value="{}" type="string" />'.format(k, quote(v))
 
     for onenode in graph.nodes(data=True):
         id = onenode[0]
@@ -175,29 +191,15 @@ def XGMMLWriter(file, graph, graph_name):
         else:
             label = id
         
-        print >>file, '<node id="{id}" label="{label}">'.format(id=id, label=label)
+        print >>file, '  <node id="{id}" label="{label}">'.format(id=id, label=label)
         for k, v in attr.iteritems():
-            if isinstance(v, int):
-                print >>file, '<att name="{}" value="{}" type="integer" />'.format(k, v)
-            elif isinstance(v, bool):
-                print >>file, '<att name="{}" value="{}" type="boolean" />'.format(k, v)
-            elif isinstance(v, float):
-                print >>file, '<att name="{}" value="{}" type="real" />'.format(k, v)
-            else:
-                print >>file, '<att name="{}" value="{}" type="string" />'.format(k, quote(v))
+            write_att_el(k, v, 2)
 
-        print >>file, '</node>'
+        print >>file, '  </node>'
         
     for oneedge in graph.edges(data=True):
-        print >>file, '<edge source="{}" target="{}">'.format(oneedge[0], oneedge[1])
+        print >>file, '  <edge source="{}" target="{}">'.format(oneedge[0], oneedge[1])
         for k, v in oneedge[2].iteritems():
-            if isinstance(v, int):
-                print >>file, '<att name="{}" value="{}" type="integer" />'.format(k, v)
-            elif isinstance(v, bool):
-                print >>file, '<att name="{}" value="{}" type="boolean" />'.format(k, v)
-            elif isinstance(v, float):
-                print >>file, '<att name="{}" value="{}" type="real" />'.format(k, v)
-            else:
-                print >>file, '<att name="{}" value="{}" type="string" />'.format(k, quote(v))
-        print >>file, '</edge>'
+            write_att_el(k, v, 2)
+        print >>file, '  </edge>'
     print >>file, '</graph>'


### PR DESCRIPTION
Hello,

Thanks for creating this plugin. Unfortunately, when I just tried using it on an xgmml file from a third party source, it threw this error:

```
Traceback (most recent call last):
  File "exrna_mapper.py", line 37, in <module>
    _main()
  File "exrna_mapper.py", line 18, in _main
    g = networkxgmml.XGMMLReader(options.XGMML)
  File "/Users/andersriutta/.virtualenvs/exrna-mapper/lib/python2.7/site-packages/networkxgmml.py", line 111, in XGMMLReader
    parser.parseFile(file)
  File "/Users/andersriutta/.virtualenvs/exrna-mapper/lib/python2.7/site-packages/networkxgmml.py", line 83, in parseFile
    self._parser.ParseFile(file)
  File "/Users/andersriutta/.virtualenvs/exrna-mapper/lib/python2.7/site-packages/networkxgmml.py", line 67, in _end_element
    self._graph.add_node(self._current_obj['id'], label=self._current_obj['label'], **self._current_attr)
TypeError: add_node() got multiple values for keyword argument 'label'
```

It's because of a conflict that happens when a `node` element has attribute of `label="anything"`, and that `node` element also has an `att` element with its own attribute of `name="label"`, as you can see in [this example](https://github.com/ariutta/networkxxgmml/blob/cbcf0aeec4cb9bfa371b87946f556387863522d4/example/mirtarbase-sample.xgmml#L13).

My pull request changes `label` to `@label` when it's the value of a name attribute for the `att` element. This is based on the [JXON](https://developer.mozilla.org/en-US/docs/JXON) convention, but I'm open to alternatives if there's a more standard xgmml way of doing this.
